### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Fix for [https://github.com/langchain-ai/openwork/security/code-scanning/2](https://github.com/langchain-ai/openwork/security/code-scanning/2)
