### PR TITLE
Add Azure OpenAI provider and configuration support

### DIFF
--- a/src/main/ipc/agent.ts
+++ b/src/main/ipc/agent.ts
@@ -3,6 +3,7 @@ import { HumanMessage } from '@langchain/core/messages'
 import { Command } from '@langchain/langgraph'
 import { createAgentRuntime } from '../agent/runtime'
 import { getThread } from '../db'
+import { getDefaultModel } from './models'
 import type { HITLDecision } from '../types'
 
 // Track active runs for cancellation
@@ -62,7 +63,8 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
           return
         }
 
-        const agent = await createAgentRuntime({ workspacePath })
+        const modelId = getDefaultModel()
+        const agent = await createAgentRuntime({ workspacePath, modelId })
         const humanMessage = new HumanMessage(message)
 
         // Stream with both modes:
@@ -152,7 +154,8 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
       activeRuns.set(threadId, abortController)
 
       try {
-        const agent = await createAgentRuntime({ workspacePath })
+        const modelId = getDefaultModel()
+        const agent = await createAgentRuntime({ workspacePath, modelId })
         const config = {
           configurable: { thread_id: threadId },
           signal: abortController.signal,
@@ -226,7 +229,8 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
       activeRuns.set(threadId, abortController)
 
       try {
-        const agent = await createAgentRuntime({ workspacePath })
+        const modelId = getDefaultModel()
+        const agent = await createAgentRuntime({ workspacePath, modelId })
         const config = {
           configurable: { thread_id: threadId },
           signal: abortController.signal,

--- a/src/main/storage.ts
+++ b/src/main/storage.ts
@@ -9,7 +9,8 @@ const ENV_FILE = join(OPENWORK_DIR, '.env')
 const ENV_VAR_NAMES: Record<string, string> = {
   anthropic: 'ANTHROPIC_API_KEY',
   openai: 'OPENAI_API_KEY',
-  google: 'GOOGLE_API_KEY'
+  google: 'GOOGLE_API_KEY',
+  azure: 'AZURE_OPENAI_API_KEY'
 }
 
 export function getOpenworkDir(): string {
@@ -100,4 +101,143 @@ export function deleteApiKey(provider: string): void {
 
 export function hasApiKey(provider: string): boolean {
   return !!getApiKey(provider)
+}
+
+// Azure OpenAI configuration interface
+export interface AzureConfig {
+  endpoint: string
+  deployment: string
+  apiVersion: string
+}
+
+// Parse Azure Target URI (e.g., https://AIF-ABL.cognitiveservices.azure.com/openai/deployments/gpt-4.1/chat/completions?api-version=2024-05-01-preview)
+// Returns endpoint (base URL) and apiVersion, or null if parsing fails
+function parseAzureTargetUri(targetUri: string): { endpoint: string; apiVersion: string } | null {
+  try {
+    const url = new URL(targetUri)
+    const apiVersion = url.searchParams.get('api-version')
+    
+    if (!apiVersion) {
+      return null
+    }
+    
+    // Extract base endpoint: remove /deployments/... and query params
+    const pathParts = url.pathname.split('/')
+    const deploymentsIndex = pathParts.indexOf('deployments')
+    if (deploymentsIndex === -1) {
+      return null
+    }
+    
+    // Build base endpoint: protocol + host + path up to /openai
+    const basePath = pathParts.slice(0, deploymentsIndex).join('/')
+    const endpoint = `${url.protocol}//${url.host}${basePath}`
+    
+    return { endpoint, apiVersion }
+  } catch {
+    return null
+  }
+}
+
+// Normalize Azure endpoint: store as origin (no trailing slash) and strip any /openai/... suffix.
+function normalizeAzureEndpoint(endpoint: string): string {
+  const trimmed = endpoint.trim()
+
+  // AzureChatOpenAI expects a base endpoint (e.g. https://<resource>.openai.azure.com/)
+  // The Azure portal often provides URLs that include /openai/... which we should strip.
+  try {
+    const url = new URL(trimmed)
+
+    // Some Azure portals show `https://<resource>.cognitiveservices.azure.com/openai/...`
+    // LangChain's Azure OpenAI utilities expect the OpenAI host form:
+    // `https://<resource>.openai.azure.com/`
+    const host = url.host.toLowerCase()
+    if (host.endsWith('.cognitiveservices.azure.com')) {
+      const resourceName = url.host.split('.')[0]
+      url.host = `${resourceName}.openai.azure.com`
+    }
+
+    const pathname = url.pathname || '/'
+    const openaiIndex = pathname.toLowerCase().indexOf('/openai')
+    const basePath = openaiIndex >= 0 ? pathname.slice(0, openaiIndex) : pathname
+
+    // Persist without a trailing slash to avoid accidental `//openai/...` when composing URLs.
+    const normalizedBasePath = basePath === '/' ? '' : basePath
+    url.pathname = normalizedBasePath
+    url.search = ''
+    url.hash = ''
+
+    // Use origin + pathname to avoid `https://host/` trailing slash when pathname is empty.
+    return `${url.origin}${url.pathname}`
+  } catch {
+    const openaiIndex = trimmed.toLowerCase().indexOf('/openai')
+    const base = openaiIndex >= 0 ? trimmed.slice(0, openaiIndex) : trimmed
+    return base.endsWith('/') ? base.slice(0, -1) : base
+  }
+}
+
+// Get Azure OpenAI configuration
+export function getAzureConfig(): AzureConfig | null {
+  const env = parseEnvFile()
+  
+  const endpoint = env.AZURE_OPENAI_ENDPOINT
+  const deployment = env.AZURE_OPENAI_DEPLOYMENT
+  const apiVersion = env.AZURE_OPENAI_API_VERSION
+  
+  if (!endpoint || !deployment || !apiVersion) {
+    return null
+  }
+  
+  return {
+    endpoint: normalizeAzureEndpoint(endpoint),
+    deployment,
+    apiVersion
+  }
+}
+
+// Set Azure OpenAI configuration
+export function setAzureConfig(config: AzureConfig): void {
+  const env = parseEnvFile()
+  
+  env.AZURE_OPENAI_ENDPOINT = normalizeAzureEndpoint(config.endpoint)
+  env.AZURE_OPENAI_DEPLOYMENT = config.deployment
+  env.AZURE_OPENAI_API_VERSION = config.apiVersion
+  
+  writeEnvFile(env)
+}
+
+// Set Azure endpoint (accepts either base endpoint or full Target URI)
+export function setAzureEndpoint(endpointOrUri: string): { endpoint: string; apiVersion?: string } | null {
+  const parsed = parseAzureTargetUri(endpointOrUri)
+  
+  if (parsed) {
+    // User pasted Target URI - extract endpoint and apiVersion
+    const env = parseEnvFile()
+    env.AZURE_OPENAI_ENDPOINT = normalizeAzureEndpoint(parsed.endpoint)
+    if (parsed.apiVersion) {
+      env.AZURE_OPENAI_API_VERSION = parsed.apiVersion
+    }
+    writeEnvFile(env)
+    return { endpoint: parsed.endpoint, apiVersion: parsed.apiVersion }
+  } else {
+    // User pasted base endpoint - just store it
+    const env = parseEnvFile()
+    env.AZURE_OPENAI_ENDPOINT = normalizeAzureEndpoint(endpointOrUri)
+    writeEnvFile(env)
+    return { endpoint: normalizeAzureEndpoint(endpointOrUri) }
+  }
+}
+
+// Check if Azure OpenAI is fully configured (needs key + endpoint + deployment + apiVersion)
+export function hasAzureConfig(): boolean {
+  const apiKey = getApiKey('azure')
+  const config = getAzureConfig()
+  return !!apiKey && !!config
+}
+
+// Check if a provider is configured (handles special cases like Azure)
+export function isProviderConfigured(provider: string): boolean {
+  if (provider === 'azure') {
+    return hasAzureConfig()
+  }
+  return hasApiKey(provider)
 }

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -25,7 +25,7 @@ export interface Run {
 }
 
 // Provider configuration
-export type ProviderId = 'anthropic' | 'openai' | 'google' | 'ollama'
+export type ProviderId = 'anthropic' | 'openai' | 'google' | 'ollama' | 'azure'
 
 export interface Provider {
   id: ProviderId

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -46,6 +46,9 @@ interface CustomAPI {
     setDefault: (modelId: string) => Promise<void>
     setApiKey: (provider: string, apiKey: string) => Promise<void>
     getApiKey: (provider: string) => Promise<string | null>
+    getAzureConfig: () => Promise<{ endpoint: string; deployment: string; apiVersion: string } | null>
+    setAzureConfig: (config: { endpoint: string; deployment: string; apiVersion: string }) => Promise<void>
+    setAzureEndpoint: (endpointOrUri: string) => Promise<{ endpoint: string; apiVersion?: string } | null>
   }
   workspace: {
     get: (threadId?: string) => Promise<string | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -146,6 +146,15 @@ const api = {
     },
     deleteApiKey: (provider: string): Promise<void> => {
       return ipcRenderer.invoke('models:deleteApiKey', provider)
+    },
+    getAzureConfig: (): Promise<{ endpoint: string; deployment: string; apiVersion: string } | null> => {
+      return ipcRenderer.invoke('models:getAzureConfig')
+    },
+    setAzureConfig: (config: { endpoint: string; deployment: string; apiVersion: string }): Promise<void> => {
+      return ipcRenderer.invoke('models:setAzureConfig', config)
+    },
+    setAzureEndpoint: (endpointOrUri: string): Promise<{ endpoint: string; apiVersion?: string } | null> => {
+      return ipcRenderer.invoke('models:setAzureEndpoint', endpointOrUri)
     }
   },
   workspace: {

--- a/src/renderer/src/components/chat/ModelSwitcher.tsx
+++ b/src/renderer/src/components/chat/ModelSwitcher.tsx
@@ -32,10 +32,19 @@ function GoogleIcon({ className }: { className?: string }) {
   )
 }
 
+function AzureIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M11.4 24H0V12.6h11.4V24zM24 24H12.6V12.6H24V24zM11.4 11.4H0V0h11.4v11.4zM24 11.4H12.6V0H24v11.4z"/>
+    </svg>
+  )
+}
+
 const PROVIDER_ICONS: Record<ProviderId, React.FC<{ className?: string }>> = {
   anthropic: AnthropicIcon,
   openai: OpenAIIcon,
   google: GoogleIcon,
+  azure: AzureIcon,
   ollama: () => null // No icon for ollama yet
 }
 
@@ -43,7 +52,8 @@ const PROVIDER_ICONS: Record<ProviderId, React.FC<{ className?: string }>> = {
 const FALLBACK_PROVIDERS: Provider[] = [
   { id: 'anthropic', name: 'Anthropic', hasApiKey: false },
   { id: 'openai', name: 'OpenAI', hasApiKey: false },
-  { id: 'google', name: 'Google', hasApiKey: false }
+  { id: 'google', name: 'Google', hasApiKey: false },
+  { id: 'azure', name: 'Azure OpenAI', hasApiKey: false }
 ]
 
 export function ModelSwitcher() {
@@ -58,7 +68,7 @@ export function ModelSwitcher() {
     currentModel, 
     loadModels, 
     loadProviders,
-    setCurrentModel 
+    setCurrentModel
   } = useAppStore()
 
   // Load models and providers on mount
@@ -125,7 +135,7 @@ export function ModelSwitcher() {
             {selectedModel ? (
               <>
                 {PROVIDER_ICONS[selectedModel.provider]?.({ className: 'size-3.5' })}
-                <span className="font-mono">{selectedModel.id}</span>
+                <span className="font-mono">{selectedModel.name ?? selectedModel.id}</span>
               </>
             ) : (
               <span>Select model</span>
@@ -180,13 +190,15 @@ export function ModelSwitcher() {
                 <div className="flex flex-col items-center justify-center h-[180px] px-4 text-center">
                   <Key className="size-6 text-muted-foreground mb-2" />
                   <p className="text-xs text-muted-foreground mb-3">
-                    API key required for {selectedProvider.name}
+                    {selectedProvider.id === 'azure'
+                      ? `Configuration required for ${selectedProvider.name}`
+                      : `API key required for ${selectedProvider.name}`}
                   </p>
                   <Button
                     size="sm"
                     onClick={() => handleConfigureApiKey(selectedProvider)}
                   >
-                    Configure API Key
+                    {selectedProvider.id === 'azure' ? 'Configure Azure' : 'Configure API Key'}
                   </Button>
                 </div>
               ) : (
@@ -204,7 +216,7 @@ export function ModelSwitcher() {
                             : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
                         )}
                       >
-                        <span className="flex-1 truncate">{model.id}</span>
+                        <span className="flex-1 truncate">{model.name ?? model.id}</span>
                         {currentModel === model.id && (
                           <Check className="size-3.5 shrink-0 text-foreground" />
                         )}

--- a/src/renderer/src/lib/store.ts
+++ b/src/renderer/src/lib/store.ts
@@ -112,8 +112,12 @@ interface AppState {
   loadModels: () => Promise<void>
   loadProviders: () => Promise<void>
   setCurrentModel: (modelId: string) => Promise<void>
+  getApiKey: (providerId: string) => Promise<string | null>
   setApiKey: (providerId: string, apiKey: string) => Promise<void>
   deleteApiKey: (providerId: string) => Promise<void>
+  getAzureConfig: () => Promise<{ endpoint: string; deployment: string; apiVersion: string } | null>
+  setAzureConfig: (config: { endpoint: string; deployment: string; apiVersion: string }) => Promise<void>
+  setAzureEndpoint: (endpointOrUri: string) => Promise<{ endpoint: string; apiVersion?: string } | null>
 
   // Panel actions
   setRightPanelTab: (tab: 'todos' | 'files' | 'subagents') => void
@@ -510,6 +514,10 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({ currentModel: modelId })
   },
 
+  getApiKey: async (providerId: string) => {
+    return window.api.models.getApiKey(providerId)
+  },
+
   setApiKey: async (providerId: string, apiKey: string) => {
     console.log('[Store] setApiKey called:', { providerId, keyLength: apiKey.length })
     try {
@@ -530,6 +538,23 @@ export const useAppStore = create<AppState>((set, get) => ({
     // Reload providers and models to update availability
     await get().loadProviders()
     await get().loadModels()
+  },
+
+  getAzureConfig: async () => {
+    return window.api.models.getAzureConfig()
+  },
+
+  setAzureConfig: async (config: { endpoint: string; deployment: string; apiVersion: string }) => {
+    await window.api.models.setAzureConfig(config)
+    await get().loadProviders()
+    await get().loadModels()
+  },
+
+  setAzureEndpoint: async (endpointOrUri: string) => {
+    const result = await window.api.models.setAzureEndpoint(endpointOrUri)
+    await get().loadProviders()
+    await get().loadModels()
+    return result
   },
 
   // Panel actions

--- a/src/renderer/src/types.ts
+++ b/src/renderer/src/types.ts
@@ -24,7 +24,7 @@ export interface Run {
 }
 
 // Provider configuration
-export type ProviderId = 'anthropic' | 'openai' | 'google' | 'ollama'
+export type ProviderId = 'anthropic' | 'openai' | 'google' | 'ollama' | 'azure'
 
 export interface Provider {
   id: ProviderId


### PR DESCRIPTION
## Description

Adds **Azure OpenAI** as a new provider alongside Anthropic/OpenAI/Google, supporting Azure’s deployment-based chat models. This includes Azure-specific configuration (**API key, endpoint or Target URI, deployment name, API version**) stored in `~/.openwork/.env`, IPC handlers to read/write config, model availability checks, and runtime instantiation via LangChain’s `AzureChatOpenAI`. The model picker and per-provider configuration modal were updated so users can configure Azure and select the configured deployment.

## Related Issue

Fixes N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] I have tested my changes locally
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)


- Azure provider in model switcher:
<img width="484" height="304" alt="image" src="https://github.com/user-attachments/assets/6433b03a-3b6d-475f-858c-fea06a7a4b6c" />

- Azure configuration modal (API key + endpoint/Target URI + deployment + API version):
<img width="430" height="545" alt="image" src="https://github.com/user-attachments/assets/c4c7961f-0eec-437a-ab55-0c4265c531a2" />

- Working example: 
<img width="818" height="835" alt="image" src="https://github.com/user-attachments/assets/0bcfe305-c76b-4e74-a7a8-cf655e6decd5" />


## Additional Notes

- Azure endpoints are normalized (e.g., stripping `/openai/...`, removing trailing slashes, and rewriting `*.cognitiveservices.azure.com` to `*.openai.azure.com` when applicable).
- Saved API keys are not displayed again for security; the dialog only shows a placeholder when a key already exists.