### PR TITLE
fix: pass selected model to backend when invoking agent

### DIFF
--- a/src/main/ipc/agent.ts
+++ b/src/main/ipc/agent.ts
@@ -14,13 +14,14 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
   // Handle agent invocation with streaming
   ipcMain.on(
     'agent:invoke',
-    async (event, { threadId, message }: { threadId: string; message: string }) => {
+    async (event, { threadId, message, modelId }: { threadId: string; message: string; modelId?: string }) => {
       const channel = `agent:stream:${threadId}`
       const window = BrowserWindow.fromWebContents(event.sender)
 
       console.log('[Agent] Received invoke request:', {
         threadId,
-        message: message.substring(0, 50)
+        message: message.substring(0, 50),
+        modelId
       })
 
       if (!window) {
@@ -62,7 +63,7 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
           return
         }
 
-        const agent = await createAgentRuntime({ threadId, workspacePath })
+        const agent = await createAgentRuntime({ threadId, workspacePath, modelId })
         const humanMessage = new HumanMessage(message)
 
         // Stream with both modes:
@@ -126,13 +127,14 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
       event,
       {
         threadId,
-        command
-      }: { threadId: string; command: { resume?: { decision?: string } } }
+        command,
+        modelId
+      }: { threadId: string; command: { resume?: { decision?: string } }; modelId?: string }
     ) => {
       const channel = `agent:stream:${threadId}`
       const window = BrowserWindow.fromWebContents(event.sender)
 
-      console.log('[Agent] Received resume request:', { threadId, command })
+      console.log('[Agent] Received resume request:', { threadId, command, modelId })
 
       if (!window) {
         console.error('[Agent] No window found for resume')
@@ -163,7 +165,7 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
       activeRuns.set(threadId, abortController)
 
       try {
-        const agent = await createAgentRuntime({ threadId, workspacePath })
+        const agent = await createAgentRuntime({ threadId, workspacePath, modelId })
         const config = {
           configurable: { thread_id: threadId },
           signal: abortController.signal,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -27,7 +27,8 @@ const api = {
     invoke: (
       threadId: string,
       message: string,
-      onEvent: (event: StreamEvent) => void
+      onEvent: (event: StreamEvent) => void,
+      modelId?: string
     ): (() => void) => {
       const channel = `agent:stream:${threadId}`
 
@@ -39,7 +40,7 @@ const api = {
       }
 
       ipcRenderer.on(channel, handler)
-      ipcRenderer.send('agent:invoke', { threadId, message })
+      ipcRenderer.send('agent:invoke', { threadId, message, modelId })
 
       // Return cleanup function
       return () => {
@@ -51,7 +52,8 @@ const api = {
       threadId: string,
       message: string,
       command: unknown,
-      onEvent: (event: StreamEvent) => void
+      onEvent: (event: StreamEvent) => void,
+      modelId?: string
     ): (() => void) => {
       const channel = `agent:stream:${threadId}`
 
@@ -66,9 +68,9 @@ const api = {
 
       // If we have a command, it might be a resume/retry
       if (command) {
-        ipcRenderer.send('agent:resume', { threadId, command })
+        ipcRenderer.send('agent:resume', { threadId, command, modelId })
       } else {
-        ipcRenderer.send('agent:invoke', { threadId, message })
+        ipcRenderer.send('agent:invoke', { threadId, message, modelId })
       }
 
       // Return cleanup function

--- a/src/renderer/src/components/chat/ChatContainer.tsx
+++ b/src/renderer/src/components/chat/ChatContainer.tsx
@@ -67,12 +67,15 @@ export function ChatContainer({ threadId }: ChatContainerProps): React.JSX.Eleme
       setPendingApproval(null)
 
       try {
-        await stream.submit(null, { command: { resume: { decision } } })
+        await stream.submit(null, {
+          command: { resume: { decision } },
+          config: { configurable: { thread_id: threadId, model_id: currentModel } }
+        })
       } catch (err) {
         console.error('[ChatContainer] Resume command failed:', err)
       }
     },
-    [pendingApproval, setPendingApproval, stream]
+    [pendingApproval, setPendingApproval, stream, threadId, currentModel]
   )
 
   const agentValues = stream?.values as AgentStreamValues | undefined
@@ -252,7 +255,7 @@ export function ChatContainer({ threadId }: ChatContainerProps): React.JSX.Eleme
       },
       {
         config: {
-          configurable: { thread_id: threadId }
+          configurable: { thread_id: threadId, model_id: currentModel }
         }
       }
     )


### PR DESCRIPTION
## Summary

- Fixes the bug where selecting a Gemini (or OpenAI) model in the UI still resulted in "Anthropic API key not configured" error
- The selected model was stored in UI state but never passed through the IPC chain to the backend

## Changes

The fix passes `modelId` through the entire IPC chain:

1. **ChatContainer.tsx** - Include `model_id` in `stream.submit()` config
2. **electron-transport.ts** - Extract `model_id` from config and pass to `streamAgent()`
3. **preload/index.ts** - Forward `modelId` in IPC messages to main process
4. **agent.ts** - Extract `modelId` and pass to `createAgentRuntime()`

## Test plan

- [x] Select a Gemini model in the model switcher
- [x] Configure only a Google API key (no Anthropic key)
- [x] Send a message
- [x] Verify the agent uses the Gemini model instead of erroring about missing Anthropic key

Fixes #12