### PR TITLE
Add Gemini 3 Flash Preview model

### DIFF
--- a/src/main/ipc/agent.ts
+++ b/src/main/ipc/agent.ts
@@ -14,13 +14,17 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
   // Handle agent invocation with streaming
   ipcMain.on(
     'agent:invoke',
-    async (event, { threadId, message }: { threadId: string; message: string }) => {
+    async (
+      event,
+      { threadId, message, modelId }: { threadId: string; message: string; modelId?: string }
+    ) => {
       const channel = `agent:stream:${threadId}`
       const window = BrowserWindow.fromWebContents(event.sender)
 
       console.log('[Agent] Received invoke request:', {
         threadId,
-        message: message.substring(0, 50)
+        message: message.substring(0, 50),
+        modelId
       })
 
       if (!window) {
@@ -62,7 +66,7 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
           return
         }
 
-        const agent = await createAgentRuntime({ threadId, workspacePath })
+        const agent = await createAgentRuntime({ threadId, workspacePath, modelId })
         const humanMessage = new HumanMessage(message)
 
         // Stream with both modes:
@@ -126,13 +130,14 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
       event,
       {
         threadId,
-        command
-      }: { threadId: string; command: { resume?: { decision?: string } } }
+        command,
+        modelId
+      }: { threadId: string; command: { resume?: { decision?: string } }; modelId?: string }
     ) => {
       const channel = `agent:stream:${threadId}`
       const window = BrowserWindow.fromWebContents(event.sender)
 
-      console.log('[Agent] Received resume request:', { threadId, command })
+      console.log('[Agent] Received resume request:', { threadId, command, modelId })
 
       if (!window) {
         console.error('[Agent] No window found for resume')
@@ -163,7 +168,7 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
       activeRuns.set(threadId, abortController)
 
       try {
-        const agent = await createAgentRuntime({ threadId, workspacePath })
+        const agent = await createAgentRuntime({ threadId, workspacePath, modelId })
         const config = {
           configurable: { thread_id: threadId },
           signal: abortController.signal,
@@ -214,7 +219,14 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
   // Handle HITL interrupt response
   ipcMain.on(
     'agent:interrupt',
-    async (event, { threadId, decision }: { threadId: string; decision: HITLDecision }) => {
+    async (
+      event,
+      {
+        threadId,
+        decision,
+        modelId
+      }: { threadId: string; decision: HITLDecision; modelId?: string }
+    ) => {
       const channel = `agent:stream:${threadId}`
       const window = BrowserWindow.fromWebContents(event.sender)
 
@@ -247,7 +259,7 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
       activeRuns.set(threadId, abortController)
 
       try {
-        const agent = await createAgentRuntime({ threadId, workspacePath })
+        const agent = await createAgentRuntime({ threadId, workspacePath, modelId })
         const config = {
           configurable: { thread_id: threadId },
           signal: abortController.signal,

--- a/src/main/ipc/models.ts
+++ b/src/main/ipc/models.ts
@@ -164,6 +164,14 @@ const AVAILABLE_MODELS: ModelConfig[] = [
     available: true
   },
   {
+    id: 'gemini-3-flash-preview',
+    name: 'Gemini 3 Flash Preview',
+    provider: 'google',
+    model: 'gemini-3-flash-preview',
+    description: 'Fast frontier-class model with low latency and cost',
+    available: true
+  },
+  {
     id: 'gemini-2.5-pro',
     name: 'Gemini 2.5 Pro',
     provider: 'google',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -27,6 +27,7 @@ const api = {
     invoke: (
       threadId: string,
       message: string,
+      modelId: string | undefined,
       onEvent: (event: StreamEvent) => void
     ): (() => void) => {
       const channel = `agent:stream:${threadId}`
@@ -39,7 +40,7 @@ const api = {
       }
 
       ipcRenderer.on(channel, handler)
-      ipcRenderer.send('agent:invoke', { threadId, message })
+      ipcRenderer.send('agent:invoke', { threadId, message, modelId })
 
       // Return cleanup function
       return () => {
@@ -50,6 +51,7 @@ const api = {
     streamAgent: (
       threadId: string,
       message: string,
+      modelId: string | undefined,
       command: unknown,
       onEvent: (event: StreamEvent) => void
     ): (() => void) => {
@@ -66,9 +68,9 @@ const api = {
 
       // If we have a command, it might be a resume/retry
       if (command) {
-        ipcRenderer.send('agent:resume', { threadId, command })
+        ipcRenderer.send('agent:resume', { threadId, command, modelId })
       } else {
-        ipcRenderer.send('agent:invoke', { threadId, message })
+        ipcRenderer.send('agent:invoke', { threadId, message, modelId })
       }
 
       // Return cleanup function
@@ -79,6 +81,7 @@ const api = {
     interrupt: (
       threadId: string,
       decision: HITLDecision,
+      modelId: string | undefined,
       onEvent?: (event: StreamEvent) => void
     ): (() => void) => {
       const channel = `agent:stream:${threadId}`
@@ -91,7 +94,7 @@ const api = {
       }
 
       ipcRenderer.on(channel, handler)
-      ipcRenderer.send('agent:interrupt', { threadId, decision })
+      ipcRenderer.send('agent:interrupt', { threadId, decision, modelId })
 
       // Return cleanup function
       return () => {

--- a/src/renderer/src/lib/electron-transport.ts
+++ b/src/renderer/src/lib/electron-transport.ts
@@ -156,8 +156,11 @@ export class ElectronIPCTransport implements UseStreamTransport {
       }
     }
 
+    // Get the selected model
+    const modelId = await window.api.models.getDefault()
+
     // Start the stream via IPC
-    const cleanup = window.api.agent.streamAgent(threadId, message, command, (ipcEvent) => {
+    const cleanup = window.api.agent.streamAgent(threadId, message, modelId, command, (ipcEvent) => {
       // Convert IPC events to SDK format
       const sdkEvents = this.convertToSDKEvents(ipcEvent as IPCEvent, threadId)
 

--- a/src/renderer/src/lib/thread-context.tsx
+++ b/src/renderer/src/lib/thread-context.tsx
@@ -67,7 +67,7 @@ export interface ThreadActions {
   setPendingApproval: (request: HITLRequest | null) => void
   setError: (error: string | null) => void
   clearError: () => void
-  setCurrentModel: (modelId: string) => void
+  setCurrentModel: (modelId: string) => Promise<void>
   openFile: (path: string, name: string) => void
   closeFile: (path: string) => void
   setActiveTab: (tab: 'agent' | string) => void
@@ -435,8 +435,10 @@ export function ThreadProvider({ children }: { children: ReactNode }) {
         clearError: () => {
           updateThreadState(threadId, () => ({ error: null }))
         },
-        setCurrentModel: (modelId: string) => {
+        setCurrentModel: async (modelId: string) => {
           updateThreadState(threadId, () => ({ currentModel: modelId }))
+          // Also update the global default so it gets used for new messages
+          await window.api.models.setDefault(modelId)
         },
         openFile: (path: string, name: string) => {
           updateThreadState(threadId, (state) => {


### PR DESCRIPTION
## Summary
- Add Gemini 3 Flash Preview model to available models list
- Fix critical bug where model selection was non-functional (always used Claude regardless of selection)

## Changes
1. Added gemini-3-flash-preview to models list in `src/main/ipc/models.ts`
2. Fixed model selection passing through all layers:
   - Updated IPC handlers to accept and use modelId parameter (`src/main/ipc/agent.ts`)
   - Updated preload to pass modelId through IPC (`src/preload/index.ts`)
   - Updated transport to get and pass modelId (`src/renderer/src/lib/electron-transport.ts`)
   - Fixed setCurrentModel to save global default (`src/renderer/src/lib/thread-context.tsx`)

## Testing
- Verified model selection now works end-to-end
- Confirmed requests are sent to correct provider (Google) with correct model ID
- Tested with gemini-3-flash-preview and received successful response from Google API

🤖 Generated with [Claude Code](https://claude.com/claude-code)