### PR TITLE
Add Gemini 3 Flash Preview model

### DIFF
--- a/src/main/ipc/models.ts
+++ b/src/main/ipc/models.ts
@@ -164,6 +164,14 @@ const AVAILABLE_MODELS: ModelConfig[] = [
     available: true
   },
   {
+    id: 'gemini-3-flash-preview',
+    name: 'Gemini 3 Flash Preview',
+    provider: 'google',
+    model: 'gemini-3-flash-preview',
+    description: 'Fast frontier-class model with low latency and cost',
+    available: true
+  },
+  {
     id: 'gemini-2.5-pro',
     name: 'Gemini 2.5 Pro',
     provider: 'google',


### PR DESCRIPTION
## Summary
Add Gemini 3 Flash Preview model to available models list

<img width="458" height="310" alt="Screenshot 2026-01-17 at 8 35 32 AM" src="https://github.com/user-attachments/assets/95fcccc7-ee1d-49b6-96b4-5a6e599f6976" />

Needs [this](https://github.com/langchain-ai/openwork/pull/14) PR to be merged for it to actually pass the right model id in.


## Changes
- Added gemini-3-flash-preview to models list in `src/main/ipc/models.ts`