### PR TITLE
Fix linter errors in backend & main process

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -7,10 +7,10 @@ import tailwindcss from '@tailwindcss/vite'
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
 // Plugin to copy resources to output
-function copyResources() {
+function copyResources(): { name: string; closeBundle: () => void } {
   return {
     name: 'copy-resources',
-    closeBundle() {
+    closeBundle(): void {
       const srcIcon = resolve('resources/icon.png')
       const destDir = resolve('out/resources')
       const destIcon = resolve('out/resources/icon.png')

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,32 +1,38 @@
-import { defineConfig } from "eslint/config";
-import tseslint from "@electron-toolkit/eslint-config-ts";
-import eslintConfigPrettier from "@electron-toolkit/eslint-config-prettier";
-import eslintPluginReact from "eslint-plugin-react";
-import eslintPluginReactHooks from "eslint-plugin-react-hooks";
-import eslintPluginReactRefresh from "eslint-plugin-react-refresh";
+import { defineConfig } from 'eslint/config'
+import tseslint from '@electron-toolkit/eslint-config-ts'
+import eslintConfigPrettier from '@electron-toolkit/eslint-config-prettier'
+import eslintPluginReact from 'eslint-plugin-react'
+import eslintPluginReactHooks from 'eslint-plugin-react-hooks'
+import eslintPluginReactRefresh from 'eslint-plugin-react-refresh'
 
 export default defineConfig(
-  { ignores: ["**/node_modules", "**/dist", "**/out"] },
+  { ignores: ['**/node_modules', '**/dist', '**/out'] },
   tseslint.configs.recommended,
   eslintPluginReact.configs.flat.recommended,
-  eslintPluginReact.configs.flat["jsx-runtime"],
+  eslintPluginReact.configs.flat['jsx-runtime'],
   {
     settings: {
       react: {
-        version: "detect",
-      },
-    },
+        version: 'detect'
+      }
+    }
   },
   {
-    files: ["**/*.{ts,tsx}"],
+    files: ['**/*.{ts,tsx}'],
     plugins: {
-      "react-hooks": eslintPluginReactHooks,
-      "react-refresh": eslintPluginReactRefresh,
+      'react-hooks': eslintPluginReactHooks,
+      'react-refresh': eslintPluginReactRefresh
     },
     rules: {
       ...eslintPluginReactHooks.configs.recommended.rules,
-      ...eslintPluginReactRefresh.configs.vite.rules,
-    },
+      ...eslintPluginReactRefresh.configs.vite.rules
+    }
+  },
+  {
+    files: ['**/*.js', '**/*.mjs', '**/*.cjs'],
+    rules: {
+      '@typescript-eslint/explicit-function-return-type': 'off'
+    }
   },
   eslintConfigPrettier
-);
+)

--- a/src/main/agent/runtime.ts
+++ b/src/main/agent/runtime.ts
@@ -59,7 +59,9 @@ export async function closeCheckpointer(threadId: string): Promise<void> {
 }
 
 // Get the appropriate model instance based on configuration
-function getModelInstance(modelId?: string): ChatAnthropic | ChatOpenAI | ChatGoogleGenerativeAI | string {
+function getModelInstance(
+  modelId?: string
+): ChatAnthropic | ChatOpenAI | ChatGoogleGenerativeAI | string {
   const model = modelId || getDefaultModel()
   console.log('[Runtime] Using model:', model)
 

--- a/src/main/checkpointer/sqljs-saver.ts
+++ b/src/main/checkpointer/sqljs-saver.ts
@@ -1,5 +1,13 @@
 import initSqlJs, { Database as SqlJsDatabase } from 'sql.js'
-import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync, renameSync, unlinkSync } from 'fs'
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+  statSync,
+  renameSync,
+  unlinkSync
+} from 'fs'
 import { dirname } from 'path'
 import type { RunnableConfig } from '@langchain/core/runnables'
 import {

--- a/src/main/ipc/agent.ts
+++ b/src/main/ipc/agent.ts
@@ -130,7 +130,7 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
         command,
         modelId
       }: { threadId: string; command: { resume?: { decision?: string } }; modelId?: string }
-    ) => {
+    ): Promise<void> => {
       const channel = `agent:stream:${threadId}`
       const window = BrowserWindow.fromWebContents(event.sender)
 

--- a/src/main/ipc/threads.ts
+++ b/src/main/ipc/threads.ts
@@ -12,7 +12,7 @@ import { deleteThreadCheckpoint } from '../storage'
 import { generateTitle } from '../services/title-generator'
 import type { Thread } from '../types'
 
-export function registerThreadHandlers(ipcMain: IpcMain) {
+export function registerThreadHandlers(ipcMain: IpcMain): void {
   // List all threads
   ipcMain.handle('threads:list', async () => {
     const threads = getAllThreads()
@@ -68,9 +68,9 @@ export function registerThreadHandlers(ipcMain: IpcMain) {
 
       if (updates.title !== undefined) updateData.title = updates.title
       if (updates.status !== undefined) updateData.status = updates.status
-      if (updates.metadata !== undefined)
-        updateData.metadata = JSON.stringify(updates.metadata)
-      if (updates.thread_values !== undefined) updateData.thread_values = JSON.stringify(updates.thread_values)
+      if (updates.metadata !== undefined) updateData.metadata = JSON.stringify(updates.metadata)
+      if (updates.thread_values !== undefined)
+        updateData.thread_values = JSON.stringify(updates.thread_values)
 
       const row = dbUpdateThread(threadId, updateData)
       if (!row) throw new Error('Thread not found')
@@ -90,7 +90,7 @@ export function registerThreadHandlers(ipcMain: IpcMain) {
   // Delete a thread
   ipcMain.handle('threads:delete', async (_event, threadId: string) => {
     console.log('[Threads] Deleting thread:', threadId)
-    
+
     // Delete from our metadata store
     dbDeleteThread(threadId)
     console.log('[Threads] Deleted from metadata store')

--- a/src/main/services/title-generator.ts
+++ b/src/main/services/title-generator.ts
@@ -1,45 +1,45 @@
 /**
  * Generate a short, descriptive title from a user's first message.
- * 
+ *
  * Uses heuristics to extract a meaningful title:
  * - For short messages: use as-is
  * - For questions: use the first sentence/question
  * - For longer text: use first N words
- * 
+ *
  * @param message - The user's first message
  * @returns A short title (max ~50 chars)
  */
 export function generateTitle(message: string): string {
   // Clean up the message
   const cleaned = message.trim().replace(/\s+/g, ' ')
-  
+
   // If already short enough, use as-is
   if (cleaned.length <= 50) {
     return cleaned
   }
-  
+
   // Try to extract first sentence/question
   const sentenceMatch = cleaned.match(/^[^.!?]+[.!?]/)
   if (sentenceMatch && sentenceMatch[0].length <= 60) {
     return sentenceMatch[0].trim()
   }
-  
+
   // Extract first N words
   const words = cleaned.split(/\s+/)
   let title = ''
-  
+
   for (const word of words) {
     if ((title + ' ' + word).length > 47) {
       break
     }
     title = title ? title + ' ' + word : word
   }
-  
+
   // Add ellipsis if we truncated
   if (words.join(' ').length > title.length) {
     title += '...'
   }
-  
+
   return title
 }
 

--- a/src/main/storage.ts
+++ b/src/main/storage.ts
@@ -75,7 +75,7 @@ function parseEnvFile(): Record<string, string> {
 function writeEnvFile(env: Record<string, string>): void {
   getOpenworkDir() // ensure dir exists
   const lines = Object.entries(env)
-    .filter(([_, v]) => v)
+    .filter(([, v]) => v)
     .map(([k, v]) => `${k}=${v}`)
   writeFileSync(getEnvFilePath(), lines.join('\n') + '\n')
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -62,14 +62,20 @@ interface CustomAPI {
       workspacePath?: string
       error?: string
     }>
-    readFile: (threadId: string, filePath: string) => Promise<{
+    readFile: (
+      threadId: string,
+      filePath: string
+    ) => Promise<{
       success: boolean
       content?: string
       size?: number
       modified_at?: string
       error?: string
     }>
-    readBinaryFile: (threadId: string, filePath: string) => Promise<{
+    readBinaryFile: (
+      threadId: string,
+      filePath: string
+    ) => Promise<{
       success: boolean
       content?: string
       size?: number

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -160,7 +160,9 @@ const api = {
     select: (threadId?: string): Promise<string | null> => {
       return ipcRenderer.invoke('workspace:select', threadId)
     },
-    loadFromDisk: (threadId: string): Promise<{
+    loadFromDisk: (
+      threadId: string
+    ): Promise<{
       success: boolean
       files: Array<{
         path: string
@@ -173,7 +175,10 @@ const api = {
     }> => {
       return ipcRenderer.invoke('workspace:loadFromDisk', { threadId })
     },
-    readFile: (threadId: string, filePath: string): Promise<{
+    readFile: (
+      threadId: string,
+      filePath: string
+    ): Promise<{
       success: boolean
       content?: string
       size?: number
@@ -182,7 +187,10 @@ const api = {
     }> => {
       return ipcRenderer.invoke('workspace:readFile', { threadId, filePath })
     },
-    readBinaryFile: (threadId: string, filePath: string): Promise<{
+    readBinaryFile: (
+      threadId: string,
+      filePath: string
+    ): Promise<{
       success: boolean
       content?: string
       size?: number


### PR DESCRIPTION
Part 1/4 of linter cleanup. Fixes all lint errors in backend and main process.

**Stack:** **#18** → #19 → #20 → #21

## Changes
- Add missing return type annotations to TypeScript functions
- Configure ESLint to exempt .js files from return type rules
- Fix prettier formatting issues
- Fix unused variable errors