### PR TITLE
feat: add n1n provider

### DIFF
--- a/src/main/agent/runtime.ts
+++ b/src/main/agent/runtime.ts
@@ -99,6 +99,21 @@ function getModelInstance(modelId?: string): ChatAnthropic | ChatOpenAI | ChatGo
       model,
       apiKey: apiKey
     })
+  } else if (model.startsWith('n1n')) {
+    const apiKey = getApiKey('n1n')
+    console.log('[Runtime] n1n API key present:', !!apiKey)
+    if (!apiKey) {
+      throw new Error('n1n API key not configured')
+    }
+    // Extract actual model name if prefixed with 'n1n-'
+    const actualModel = model.replace(/^n1n-/, '')
+    return new ChatOpenAI({
+      model: actualModel,
+      openAIApiKey: apiKey,
+      configuration: {
+        baseURL: 'https://api.n1n.ai/v1'
+      }
+    })
   }
 
   // Default to model string (let deepagents handle it)

--- a/src/main/ipc/models.ts
+++ b/src/main/ipc/models.ts
@@ -16,11 +16,29 @@ const store = new Store({
 const PROVIDERS: Omit<Provider, 'hasApiKey'>[] = [
   { id: 'anthropic', name: 'Anthropic' },
   { id: 'openai', name: 'OpenAI' },
-  { id: 'google', name: 'Google' }
+  { id: 'google', name: 'Google' },
+  { id: 'n1n', name: 'n1n' }
 ]
 
 // Available models configuration (updated Jan 2026)
 const AVAILABLE_MODELS: ModelConfig[] = [
+  // n1n series
+  {
+    id: 'n1n-gpt-4o',
+    name: 'n1n GPT-4o',
+    provider: 'n1n',
+    model: 'gpt-4o',
+    description: 'OpenAI GPT-4o via n1n.ai',
+    available: true
+  },
+  {
+    id: 'n1n-claude-3-5-sonnet',
+    name: 'n1n Claude 3.5 Sonnet',
+    provider: 'n1n',
+    model: 'claude-3-5-sonnet-20240620',
+    description: 'Anthropic Claude 3.5 Sonnet via n1n.ai',
+    available: true
+  },
   // Anthropic Claude 4.5 series (latest as of Jan 2026)
   {
     id: 'claude-opus-4-5-20251101',

--- a/src/main/storage.ts
+++ b/src/main/storage.ts
@@ -9,7 +9,8 @@ const ENV_FILE = join(OPENWORK_DIR, '.env')
 const ENV_VAR_NAMES: Record<string, string> = {
   anthropic: 'ANTHROPIC_API_KEY',
   openai: 'OPENAI_API_KEY',
-  google: 'GOOGLE_API_KEY'
+  google: 'GOOGLE_API_KEY',
+  n1n: 'N1N_API_KEY'
 }
 
 export function getOpenworkDir(): string {

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -25,7 +25,7 @@ export interface Run {
 }
 
 // Provider configuration
-export type ProviderId = 'anthropic' | 'openai' | 'google' | 'ollama'
+export type ProviderId = 'anthropic' | 'openai' | 'google' | 'ollama' | 'n1n'
 
 export interface Provider {
   id: ProviderId

--- a/src/renderer/src/types.ts
+++ b/src/renderer/src/types.ts
@@ -24,7 +24,7 @@ export interface Run {
 }
 
 // Provider configuration
-export type ProviderId = 'anthropic' | 'openai' | 'google' | 'ollama'
+export type ProviderId = 'anthropic' | 'openai' | 'google' | 'ollama' | 'n1n'
 
 export interface Provider {
   id: ProviderId


### PR DESCRIPTION
Add n1n.ai as an OpenAI-compatible provider. Includes support for GPT-4o and Claude 3.5 Sonnet via n1n.ai.