### PR TITLE
feat: add theme support and default model persistence

### DIFF
--- a/src/main/ipc/models.ts
+++ b/src/main/ipc/models.ts
@@ -164,6 +164,14 @@ const AVAILABLE_MODELS: ModelConfig[] = [
     available: true
   },
   {
+    id: 'gemini-3-flash-preview',
+    name: 'Gemini 3 Flash Preview',
+    provider: 'google',
+    model: 'gemini-3-flash-preview',
+    description: 'Fast and efficient model for complex reasoning and coding',
+    available: true
+  },
+  {
     id: 'gemini-2.5-pro',
     name: 'Gemini 2.5 Pro',
     provider: 'google',

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -3,7 +3,7 @@ import { ThreadSidebar } from '@/components/sidebar/ThreadSidebar'
 import { TabbedPanel, TabBar } from '@/components/tabs'
 import { RightPanel } from '@/components/panels/RightPanel'
 import { ResizeHandle } from '@/components/ui/resizable'
-import { useAppStore } from '@/lib/store'
+import { useAppStore, applyTheme } from '@/lib/store'
 import { ThreadProvider } from '@/lib/thread-context'
 
 // Badge requires ~235 screen pixels to display with comfortable margin
@@ -16,7 +16,7 @@ const RIGHT_MAX = 450
 const RIGHT_DEFAULT = 320
 
 function App(): React.JSX.Element {
-  const { currentThreadId, loadThreads, createThread } = useAppStore()
+  const { currentThreadId, loadThreads, createThread, theme, initializeTheme } = useAppStore()
   const [isLoading, setIsLoading] = useState(true)
   const [leftWidth, setLeftWidth] = useState(LEFT_DEFAULT)
   const [rightWidth, setRightWidth] = useState(RIGHT_DEFAULT)
@@ -24,6 +24,24 @@ function App(): React.JSX.Element {
 
   // Track drag start widths
   const dragStartWidths = useRef<{ left: number; right: number } | null>(null)
+
+  // Initialize theme on mount
+  useLayoutEffect(() => {
+    initializeTheme()
+  }, [initializeTheme])
+
+  // Listen for system preference changes when theme is set to 'system'
+  useEffect(() => {
+    if (theme !== 'system') return
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const handleChange = (): void => {
+      applyTheme('system')
+    }
+
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [theme])
 
   // Track zoom level changes and update CSS custom properties for safe areas
   useLayoutEffect(() => {

--- a/src/renderer/src/components/chat/ModelSwitcher.tsx
+++ b/src/renderer/src/components/chat/ModelSwitcher.tsx
@@ -95,6 +95,8 @@ export function ModelSwitcher({ threadId }: ModelSwitcherProps) {
 
   function handleModelSelect(modelId: string) {
     setCurrentModel(modelId)
+    // Save as default for new threads and app restarts
+    window.api.models.setDefault(modelId)
     setOpen(false)
   }
 

--- a/src/renderer/src/components/settings/SettingsDialog.tsx
+++ b/src/renderer/src/components/settings/SettingsDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Eye, EyeOff, Check, AlertCircle, Loader2 } from 'lucide-react'
+import { Eye, EyeOff, Check, AlertCircle, Loader2, Sun, Moon, Monitor } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
@@ -10,6 +10,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
+import { useAppStore, type Theme } from '@/lib/store'
 
 interface SettingsDialogProps {
   open: boolean
@@ -44,7 +45,14 @@ const PROVIDERS: ProviderConfig[] = [
   }
 ]
 
+const THEME_OPTIONS: { id: Theme; label: string; icon: typeof Sun }[] = [
+  { id: 'light', label: 'Light', icon: Sun },
+  { id: 'dark', label: 'Dark', icon: Moon },
+  { id: 'system', label: 'System', icon: Monitor }
+]
+
 export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
+  const { theme, setTheme } = useAppStore()
   const [apiKeys, setApiKeys] = useState<Record<string, string>>({})
   const [savedKeys, setSavedKeys] = useState<Record<string, boolean>>({})
   const [showKeys, setShowKeys] = useState<Record<string, boolean>>({})
@@ -200,6 +208,39 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
               ))}
             </div>
           )}
+        </div>
+
+        <Separator />
+
+        <div className="space-y-4 py-2">
+          <div className="text-section-header">APPEARANCE</div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Theme</label>
+            <div className="flex gap-2">
+              {THEME_OPTIONS.map((option) => {
+                const Icon = option.icon
+                const isSelected = theme === option.id
+                return (
+                  <button
+                    key={option.id}
+                    onClick={() => setTheme(option.id)}
+                    className={`flex flex-1 items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors ${
+                      isSelected
+                        ? 'border-primary bg-primary/10 text-primary'
+                        : 'border-border hover:bg-secondary'
+                    }`}
+                  >
+                    <Icon className="size-4" />
+                    {option.label}
+                  </button>
+                )
+              })}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Choose how the application appears. System will follow your OS preference.
+            </p>
+          </div>
         </div>
 
         <Separator />

--- a/src/renderer/src/components/sidebar/ThreadSidebar.tsx
+++ b/src/renderer/src/components/sidebar/ThreadSidebar.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
-import { Plus, MessageSquare, Trash2, Pencil, Loader2 } from 'lucide-react'
+import { Plus, MessageSquare, Trash2, Pencil, Loader2, Sun, Moon, Monitor, Settings } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import { useAppStore } from '@/lib/store'
+import { useAppStore, type Theme, getResolvedTheme } from '@/lib/store'
 import { useThreadStream } from '@/lib/thread-context'
 import { cn, formatRelativeTime, truncate } from '@/lib/utils'
 import {
@@ -12,7 +12,14 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger
 } from '@/components/ui/context-menu'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import type { Thread } from '@/types'
+
+const THEME_OPTIONS: { id: Theme; label: string; icon: typeof Sun }[] = [
+  { id: 'light', label: 'Light', icon: Sun },
+  { id: 'dark', label: 'Dark', icon: Moon },
+  { id: 'system', label: 'System', icon: Monitor }
+]
 
 // Thread loading indicator that subscribes to the stream context
 function ThreadLoadingIcon({ threadId }: { threadId: string }): React.JSX.Element {
@@ -129,8 +136,15 @@ export function ThreadSidebar(): React.JSX.Element {
     createThread,
     selectThread,
     deleteThread,
-    updateThread
+    updateThread,
+    theme,
+    setTheme,
+    setSettingsOpen
   } = useAppStore()
+
+  // Get the icon for the current theme
+  const resolvedTheme = getResolvedTheme(theme)
+  const ThemeIcon = resolvedTheme === 'dark' ? Moon : Sun
 
   const [editingThreadId, setEditingThreadId] = useState<string | null>(null)
   const [editingTitle, setEditingTitle] = useState('')
@@ -193,6 +207,47 @@ export function ThreadSidebar(): React.JSX.Element {
           )}
         </div>
       </ScrollArea>
+
+      {/* Footer with Theme Toggle and Settings */}
+      <div className="border-t border-border p-2 flex items-center gap-1">
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="ghost" size="icon-sm" title={`Theme: ${theme}`}>
+              <ThemeIcon className="size-4" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-36 p-1">
+            {THEME_OPTIONS.map((option) => {
+              const Icon = option.icon
+              const isSelected = theme === option.id
+              return (
+                <button
+                  key={option.id}
+                  onClick={() => setTheme(option.id)}
+                  className={cn(
+                    'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors',
+                    isSelected
+                      ? 'bg-accent text-accent-foreground'
+                      : 'hover:bg-secondary'
+                  )}
+                >
+                  <Icon className="size-4" />
+                  {option.label}
+                </button>
+              )
+            })}
+          </PopoverContent>
+        </Popover>
+
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => setSettingsOpen(true)}
+          title="Settings"
+        >
+          <Settings className="size-4" />
+        </Button>
+      </div>
     </aside>
   )
 }

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -110,6 +110,55 @@
   --sidebar-ring: #3B82F6;
 }
 
+/* Light theme */
+.light {
+  /* Foundation */
+  --background: #FAFAFA;
+  --background-elevated: #FFFFFF;
+  --background-interactive: #F0F0F5;
+  --foreground: #1A1A1F;
+
+  /* Borders */
+  --border: #E0E0E8;
+  --border-emphasis: #D0D0D8;
+  --input: #E0E0E8;
+  --ring: #3B82F6;
+
+  /* Text hierarchy */
+  --muted: #F5F5F8;
+  --muted-foreground: #6B6B78;
+  --tertiary-foreground: #9A9AA8;
+
+  /* Semantic mapping for shadcn compatibility */
+  --card: #FFFFFF;
+  --card-foreground: #1A1A1F;
+  --popover: #FFFFFF;
+  --popover-foreground: #1A1A1F;
+  --primary: #2563EB;
+  --primary-foreground: #FFFFFF;
+  --secondary: #F0F0F5;
+  --secondary-foreground: #1A1A1F;
+  --accent: #EA580C;
+  --accent-foreground: #FFFFFF;
+  --destructive: #DC2626;
+
+  /* Status colors - slightly adjusted for light background */
+  --status-critical: #DC2626;
+  --status-warning: #D97706;
+  --status-nominal: #16A34A;
+  --status-info: #2563EB;
+
+  /* Sidebar */
+  --sidebar: #F5F5F8;
+  --sidebar-foreground: #1A1A1F;
+  --sidebar-primary: #2563EB;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #E8E8F0;
+  --sidebar-accent-foreground: #1A1A1F;
+  --sidebar-border: #E0E0E8;
+  --sidebar-ring: #2563EB;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;
@@ -279,14 +328,14 @@
 }
 
 .streaming-markdown code {
-  background-color: var(--background);
+  background-color: var(--muted);
   padding: 0.125em 0.25em;
   border-radius: 3px;
   font-size: 0.875em;
 }
 
 .streaming-markdown pre {
-  background-color: var(--background);
+  background-color: var(--muted);
   padding: 0.75em 1em;
   border-radius: 3px;
   overflow-x: auto;
@@ -329,7 +378,7 @@
 }
 
 .streaming-markdown th {
-  background-color: var(--background);
+  background-color: var(--muted);
   font-weight: 600;
 }
 


### PR DESCRIPTION
## Summary

- Add theme support (light/dark/system) with persistent storage
- Implement default model persistence and loading so the selected model is remembered across sessions
- UI improvements for theme switching in settings dialog and sidebar

## Test plan

- [ ] Verify theme switching works correctly (light/dark/system modes)
- [ ] Verify selected model persists across app restarts
- [ ] Test settings dialog theme options
- [ ] Test sidebar appearance in different themes