### PR TITLE
fix: sync preload type definitions with implementation

### DIFF
--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,4 +1,4 @@
-import type { Thread, ModelConfig, StreamEvent, HITLDecision } from '../main/types'
+import type { Thread, ModelConfig, Provider, StreamEvent, HITLDecision } from '../main/types'
 
 interface ElectronAPI {
   ipcRenderer: {
@@ -15,12 +15,18 @@ interface ElectronAPI {
 
 interface CustomAPI {
   agent: {
-    invoke: (threadId: string, message: string, onEvent: (event: StreamEvent) => void) => () => void
+    invoke: (
+      threadId: string,
+      message: string,
+      onEvent: (event: StreamEvent) => void,
+      modelId?: string
+    ) => () => void
     streamAgent: (
       threadId: string,
       message: string,
       command: unknown,
-      onEvent: (event: StreamEvent) => void
+      onEvent: (event: StreamEvent) => void,
+      modelId?: string
     ) => () => void
     interrupt: (
       threadId: string,


### PR DESCRIPTION
## Description

- Add missing modelId parameter to streamAgent (fixes build error)
- Add missing modelId parameter to invoke for consistency
- Add missing Provider import

## Related Issue

Fixes `Error: src/renderer/src/lib/electron-transport.ts(182,8): error TS2554: Expected 4 arguments, but got 5.
Error: Process completed with exit code 2.` build issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] I have tested my changes locally
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Add screenshots to demonstrate UI changes.

## Additional Notes

Any additional information reviewers should know.
