### PR TITLE
fix(model): Persist selected model properly to fix Gemini API key error

### DIFF
--- a/src/main/ipc/agent.ts
+++ b/src/main/ipc/agent.ts
@@ -51,7 +51,11 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
         // Get workspace path from thread metadata - REQUIRED
         const thread = getThread(threadId)
         const metadata = thread?.metadata ? JSON.parse(thread.metadata) : {}
+        console.log('[Agent] Thread metadata:', metadata)
+
         const workspacePath = metadata.workspacePath as string | undefined
+        const modelId = metadata.model as string | undefined
+        console.log('[Agent] Extracted modelId:', modelId)
 
         if (!workspacePath) {
           window.webContents.send(channel, {
@@ -62,7 +66,7 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
           return
         }
 
-        const agent = await createAgentRuntime({ threadId, workspacePath })
+        const agent = await createAgentRuntime({ threadId, workspacePath, modelId })
         const humanMessage = new HumanMessage(message)
 
         // Stream with both modes:
@@ -143,6 +147,7 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
       const thread = getThread(threadId)
       const metadata = thread?.metadata ? JSON.parse(thread.metadata) : {}
       const workspacePath = metadata.workspacePath as string | undefined
+      const modelId = metadata.model as string | undefined
 
       if (!workspacePath) {
         window.webContents.send(channel, {
@@ -163,7 +168,7 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
       activeRuns.set(threadId, abortController)
 
       try {
-        const agent = await createAgentRuntime({ threadId, workspacePath })
+        const agent = await createAgentRuntime({ threadId, workspacePath, modelId })
         const config = {
           configurable: { thread_id: threadId },
           signal: abortController.signal,
@@ -227,6 +232,7 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
       const thread = getThread(threadId)
       const metadata = thread?.metadata ? JSON.parse(thread.metadata) : {}
       const workspacePath = metadata.workspacePath as string | undefined
+      const modelId = metadata.model as string | undefined
 
       if (!workspacePath) {
         window.webContents.send(channel, {
@@ -247,7 +253,7 @@ export function registerAgentHandlers(ipcMain: IpcMain): void {
       activeRuns.set(threadId, abortController)
 
       try {
-        const agent = await createAgentRuntime({ threadId, workspacePath })
+        const agent = await createAgentRuntime({ threadId, workspacePath, modelId })
         const config = {
           configurable: { thread_id: threadId },
           signal: abortController.signal,

--- a/src/renderer/src/lib/thread-context.tsx
+++ b/src/renderer/src/lib/thread-context.tsx
@@ -437,6 +437,15 @@ export function ThreadProvider({ children }: { children: ReactNode }) {
         },
         setCurrentModel: (modelId: string) => {
           updateThreadState(threadId, () => ({ currentModel: modelId }))
+          // Persist to backend
+          window.api.threads.get(threadId).then((thread) => {
+            if (thread) {
+              const metadata = thread.metadata || {}
+              window.api.threads.update(threadId, {
+                metadata: { ...metadata, model: modelId }
+              })
+            }
+          })
         },
         openFile: (path: string, name: string) => {
           updateThreadState(threadId, (state) => {
@@ -480,18 +489,25 @@ export function ThreadProvider({ children }: { children: ReactNode }) {
     async (threadId: string) => {
       const actions = getThreadActions(threadId)
 
-      // Load workspace path
+      // Load workspace path and thread metadata
       try {
-        const path = await window.api.workspace.get(threadId)
-        if (path) {
-          actions.setWorkspacePath(path)
-          const diskResult = await window.api.workspace.loadFromDisk(threadId)
-          if (diskResult.success) {
-            actions.setWorkspaceFiles(diskResult.files)
+        const thread = await window.api.threads.get(threadId)
+        if (thread) {
+          const metadata = thread.metadata || {}
+          if (metadata.workspacePath) {
+            actions.setWorkspacePath(metadata.workspacePath as string)
+            const diskResult = await window.api.workspace.loadFromDisk(threadId)
+            if (diskResult.success) {
+              actions.setWorkspaceFiles(diskResult.files)
+            }
+          }
+          if (metadata.model) {
+            // Update state directly to avoid triggering persistence in setCurrentModel
+            updateThreadState(threadId, () => ({ currentModel: metadata.model as string }))
           }
         }
       } catch (error) {
-        console.error('[ThreadContext] Failed to load workspace path:', error)
+        console.error('[ThreadContext] Failed to load thread details:', error)
       }
 
       // Load thread history from checkpoints


### PR DESCRIPTION
This PR fixes an issue where the selected model ID was not being correctly persisted or retrieved from thread metadata. This caused the application to default to Anthropic even when Gemini was selected, leading to errors due to missing API keys.

Changes:
- Updated src/main/ipc/agent.ts to use metadata.model.
- Updated ThreadContext and store to persist model selection.