### PR TITLE
fix: patch 16 security alerts (high+medium+low severity)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3497,7 +3497,6 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3507,7 +3506,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -4622,7 +4621,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -4921,9 +4919,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "39.2.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-39.2.7.tgz",
-      "integrity": "sha512-KU0uFS6LSTh4aOIC3miolcbizOFP7N1M46VTYVfqIgFiuA2ilfNaOHLDS9tCMvwwHRowAsvqBrh9NgMXcTOHCQ==",
+      "version": "39.8.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.6.tgz",
+      "integrity": "sha512-uWX6Jh5LmwL13VwOSKBjebI+ck+03GOwc8V2Sgbmr9pJVJ/cHfli/PkjXuRDr+hq+SLHQuT9mGHSIfScebApRA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -9054,7 +9052,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9064,7 +9061,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -9543,7 +9539,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {


### PR DESCRIPTION
## Security Alert Patch

Resolves 16 Dependabot security alerts across all severity tiers (5 high, 8 medium, 3 low).

### Packages Updated

| Package | Old Version | New Version | Strategy | Scope | CVEs Resolved |
|---------|-------------|-------------|----------|-------|---------------|
| electron | 39.2.7 | 39.8.6 | A (direct bump) | dev + runtime | 16 |

Strategy: A = lockfile-only update (`npm update electron`), version within existing `^39.2.6` range.

### CVE Details

**High (5):**
- [CVE-2026-34774](https://github.com/advisories/GHSA-532v-xpq5-8h95) — Use-after-free in offscreen child window paint callback
- [CVE-2026-34780](https://github.com/advisories/GHSA-jfqg-hf23-qpw2) — Context Isolation bypass via contextBridge VideoFrame transfer
- [CVE-2026-34771](https://github.com/advisories/GHSA-8337-3p73-46f4) — Use-after-free in WebContents fullscreen/pointer-lock/keyboard-lock permission callbacks
- [CVE-2026-34770](https://github.com/advisories/GHSA-jjp3-mq3x-295m) — Use-after-free in PowerMonitor on Windows and macOS
- [CVE-2026-34769](https://github.com/advisories/GHSA-9wfr-w7mm-pc7f) — Renderer command-line switch injection via undocumented commandLineSwitches webPreference

**Medium (8):**
- [CVE-2026-34779](https://github.com/advisories/GHSA-5rqw-r77c-jp79) — AppleScript injection in app.moveToApplicationsFolder on macOS
- [CVE-2026-34778](https://github.com/advisories/GHSA-xj5x-m3f3-5x3h) — Service worker can spoof executeJavaScript IPC replies
- [CVE-2026-34777](https://github.com/advisories/GHSA-r5p7-gp4j-qhrx) — Incorrect origin passed to permission request handler for iframe requests
- [CVE-2026-34776](https://github.com/advisories/GHSA-3c8v-cfp5-9885) — Out-of-bounds read in second-instance IPC on macOS and Linux
- [CVE-2026-34775](https://github.com/advisories/GHSA-xwr5-m59h-vwqr) — nodeIntegrationInWorker not correctly scoped in shared renderer processes
- [CVE-2026-34773](https://github.com/advisories/GHSA-mwmh-mq4g-g6gr) — Registry key path injection in app.setAsDefaultProtocolClient on Windows
- [CVE-2026-34772](https://github.com/advisories/GHSA-9w97-2464-8783) — Use-after-free in download save dialog callback
- [CVE-2026-34767](https://github.com/advisories/GHSA-4p4r-m79c-wq3v) — HTTP Response Header Injection in custom protocol handlers and webRequest

**Low (3):**
- [CVE-2026-34764](https://github.com/advisories/GHSA-8x5q-pvf5-64mp) — Use-after-free in offscreen shared texture release() callback
- [CVE-2026-34768](https://github.com/advisories/GHSA-jfqx-fxh3-c62j) — Unquoted executable path in app.setLoginItemSettings on Windows
- [CVE-2026-34766](https://github.com/advisories/GHSA-9899-m83m-qhpj) — USB device selection not validated against filtered device list

### Linear Tickets

No matching Linear tickets found for the resolved CVEs.

### Verification

- [x] All lockfiles regenerated
- [x] Linters pass (0 errors)
- [x] Type check passes

🤖 Submitted by langster-patch