### PR TITLE
fix: patch 5 security alerts (2 high, 3 moderate)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3304,6 +3304,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
@@ -3532,6 +3592,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yauzl": {
@@ -3914,6 +3975,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4391,6 +4453,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4481,6 +4544,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4493,6 +4557,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
@@ -4561,15 +4626,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/console-table-printer": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
-      "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
-      "license": "MIT",
-      "dependencies": {
-        "simple-wcswidth": "^1.1.2"
       }
     },
     "node_modules/convert-source-map": {
@@ -6058,6 +6114,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6986,23 +7043,20 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.4.6.tgz",
-      "integrity": "sha512-9aYop1fEwA8RgFuvv8XPeV9ieeSnKnVRn3bNemkFQCyINLAxfNHC547bVMW8i8MuS1F1pgKwopqhLNf80qS1bQ==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.21.tgz",
+      "integrity": "sha512-l140hzgqo91T/QKDXLEfRnnxahuwVEVohr9zqpy3BaGDeBdrPiJuNJ2TBhPZxNXNCl68IkVcn555FD3jp5peyw==",
       "license": "MIT",
       "dependencies": {
-        "@types/uuid": "^10.0.0",
-        "chalk": "^4.1.2",
-        "console-table-printer": "^2.12.1",
-        "p-queue": "^6.6.2",
-        "semver": "^7.6.3",
-        "uuid": "^10.0.0"
+        "p-queue": "6.6.2",
+        "uuid": "10.0.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "*",
         "@opentelemetry/exporter-trace-otlp-proto": "*",
         "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*"
+        "openai": "*",
+        "ws": ">=7"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
@@ -7016,19 +7070,10 @@
         },
         "openai": {
           "optional": true
+        },
+        "ws": {
+          "optional": true
         }
-      }
-    },
-    "node_modules/langsmith/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/langsmith/node_modules/uuid": {
@@ -9754,12 +9799,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/simple-wcswidth": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
-      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "license": "MIT"
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -9968,6 +10007,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -10531,9 +10571,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Security Alert Patch

Resolves all 5 open Dependabot security alerts on `main` via a lockfile-only refresh. No `package.json` changes — existing constraints already permit the fixed versions.

### Packages Updated

| Package | Old → New | Strategy | Scope | Alerts Resolved |
|---------|-----------|----------|-------|-----------------|
| `vite` | 7.3.1 → **7.3.2** | A-lockfile (constraint `^7.2.6` already allows 7.3.2) | dev-only | #35, #36, #37 |
| `langsmith` | 0.4.6 → **0.5.21** | A-lockfile (transitive; parent constraint `>=0.4.0 <1.0.0` already allows 0.5.x) | runtime (transitive) | #38, #39 |

Strategy key: **A-lockfile** = lockfile-only refresh, no manifest constraint change. Scope = `dev-only` means the dep is not shipped to end users; `runtime (transitive)` means the dep is pulled in by a runtime dep (`@langchain/core`, `langchain`) but not directly imported by openwork source.

### CVE / GHSA Details

| Alert | Severity | ID | Package | Summary |
|-------|---------:|----|---------|---------|
| #36 | High | [CVE-2026-39363](https://github.com/advisories/GHSA-p9ff-h696-f583) / GHSA-p9ff-h696-f583 | vite | Arbitrary file read via Vite dev server WebSocket |
| #35 | High | [CVE-2026-39364](https://github.com/advisories/GHSA-v2wj-q39q-566r) / GHSA-v2wj-q39q-566r | vite | `server.fs.deny` bypassed with queries |
| #37 | Moderate | [CVE-2026-39365](https://github.com/advisories/GHSA-4w7w-66w2-5vf9) / GHSA-4w7w-66w2-5vf9 | vite | Path traversal in optimized deps `.map` handling |
| #38 | Moderate | [CVE-2026-40190](https://github.com/advisories/GHSA-fw9q-39r9-c252) / GHSA-fw9q-39r9-c252 | langsmith | Prototype pollution via incomplete `__proto__` guard in internal lodash `set()` |
| #39 | Moderate | [GHSA-rr7j-v2q5-chgv](https://github.com/advisories/GHSA-rr7j-v2q5-chgv) | langsmith | Streaming token events bypass output redaction |

### Linear Tickets

No matching Linear tickets found for the resolved CVEs.

### Upstream Issues

None — all fixes come from released upstream patches.

### Breaking-Change Assessment

- **vite 7.3.1 → 7.3.2**: patch bump, no breaking changes.
- **langsmith 0.4.6 → 0.5.21**: minor bump on a 0.x package. Parent packages `@langchain/core` and `langchain` declare `langsmith: ">=0.4.0 <1.0.0"`, pre-validating compatibility across the 0.4 → 0.5 boundary. `openwork` does not import `langsmith` directly (verified via grep of `src/`), so no direct API surface is exposed to the bump.

### Verification

- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes (vite v7.3.2 builds main/preload/renderer)
- [x] `npm run lint` — 0 errors (3 pre-existing prettier warnings unrelated to this change)
- [x] `gitleaks git --staged` — clean

🤖 Submitted by langster-patch
