### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

- add weekly Dependabot updates for the root npm project
- add weekly Dependabot updates for GitHub Actions
- cap each ecosystem at 10 open Dependabot PRs

## Validation

- [x] Parsed `.github/dependabot.yml` successfully with Ruby YAML
- [x] Ran `git diff --check`
- [x] Confirmed the diff is limited to `.github/dependabot.yml`

## Notes

The repository uses `package-lock.json` and `npm ci` in CI and release workflows, so the dependency ecosystem is configured as `npm`.